### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,8 @@
 cmake_minimum_required(VERSION 3.7)
 project(oclPixelGameEngine) # You can change this with your project name!
 
+set(CMAKE_CXX_STANDARD 17)
+
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} CMakeFiles/) # Don't worry what this does, it just gives more compatability options with libraries!
 cmake_policy(SET CMP0037 OLD) # This just allows the / charicter in path names
 


### PR DESCRIPTION
Hi There!

First, thank you for your CMakeLists, it was really helpful.

I am using CLion, and my build fails without setting the c++ standard to C++17.  It appears this is also explicitly set in the build documentation in the olcPixelGameEngine.h.

On adding the set standard flag to CMakeLists, everything works - I don't know if this is the best way to set this flag, but thought I should submit it anyway.

Thanks again.